### PR TITLE
Update imgui to 0.7.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "imgui-memory-editor-sys/vendor/imgui-memory-editor"]
 	path = imgui-memory-editor-sys/vendor/imgui-memory-editor
-	url = git@github.com:ocornut/imgui_club.git
+	url = https://github.com/ocornut/imgui_club.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["imgui", "memory", "editor"]
 categories = ["gui", "api-bindings"]
 
 [dependencies]
-imgui = "0.6.1"
+imgui = "0.7.0"
 imgui-memory-editor-sys = { path = "imgui-memory-editor-sys", version = "0.2.0" }

--- a/imgui-memory-editor-sys/Cargo.toml
+++ b/imgui-memory-editor-sys/Cargo.toml
@@ -12,7 +12,7 @@ links = "imgui_memory_editor"
 
 [dependencies]
 cty = "0.2.1"
-imgui-sys = "0.6.0"
+imgui-sys = "0.7.0"
 
 [build-dependencies]
 cc = "1.0.66"

--- a/src/memory_editor.rs
+++ b/src/memory_editor.rs
@@ -1,6 +1,6 @@
 use std::ffi::c_void;
 
-use imgui::{ImColor, ImStr, Ui};
+use imgui::{ImColor32, ImStr, Ui};
 
 
 // TODO: Alias ReadHandlerTrait and writeHandlerTrait to FnMuts once trait_alias is stabilized
@@ -120,7 +120,7 @@ impl<'a, T> MemoryEditor<'a, T> {
     }
     // background color of highlighted bytes.
     #[inline]
-    pub fn highlight_color(mut self, color: ImColor) -> Self {
+    pub fn highlight_color(mut self, color: ImColor32) -> Self {
         self.raw.HighlightColor = color.into();
         self
     }


### PR DESCRIPTION
Hi!

This crate suits my needs perfectly, only it isn't updated to the latest version of imgui-rs anymore. Since this would be fairly trivial to do, I decided to do it myself :)

Also, on a slightly unrelated note (which might just be because of my setup), i had to make the following change in `.gitmodules` for it to clone correctly:
```diff
-	url = git@github.com:ocornut/imgui_club.git
+	url = https://github.com/ocornut/imgui_club.git
```
You can of course choose to not include this change if it isn't necessary.

Thanks for making this crate! 